### PR TITLE
npm linkを用いて実行しやすくする

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "start": "node src/jlse.js",
     "lint": "eslint --fix ."
   },
+  "bin": {
+    "jlse": "src/jlse.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tobitti0/join_logo_scp_trial.git"

--- a/src/jlse.js
+++ b/src/jlse.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const fs = require("fs-extra");
 const path = require("path");
 


### PR DESCRIPTION
src/jlse.jsをnpm linkで登録を行うようにした。
これによりターミナルからjlseコマンドで直接join_logo_scp_trialを実行できるようになる。